### PR TITLE
Test if fast command exists with POSIX compatible check

### DIFF
--- a/mac-cli/plugins/network
+++ b/mac-cli/plugins/network
@@ -8,8 +8,7 @@ case "$fn" in
 
     # Internet connection speed test
     "speedtest")
-
-        if [ ! -f /usr/local/lib/node_modules/fast-cli/cli.js ]; then
+        if ! [ -x "$(command -v fast)" ]; then
             read -r -p "Do you want to install the Speed Test utility? (https://github.com/sindresorhus/fast-cli) (Yes / No)" response
             case $response in
                 [yY][eE][sS]|[yY])
@@ -29,7 +28,7 @@ case "$fn" in
     # Run internet connection Speed Test each 5 minutes
     "speedtest:infinite")
 
-        if [ ! -f /usr/local/lib/node_modules/speed-test/cli.js ]; then
+        if ! [ -x "$(command -v fast)" ]; then
             read -r -p "Do you want to install the Speed Test utility? (https://github.com/sindresorhus/fast-cli) (Yes / No)" response
             case $response in
                 [yY][eE][sS]|[yY])


### PR DESCRIPTION
Those using [nvm](https://github.com/creationix/nvm) for node don't install into `/usr/local/lib/node_modules`. This change checks for the command, not the script location.